### PR TITLE
Update InterfaceStats.py

### DIFF
--- a/InterfaceStats.py
+++ b/InterfaceStats.py
@@ -213,7 +213,7 @@ def DictListToCSV(data, filename, suffix=".csv"):
                           "InputPackets", "InputErr", "OutputPackets", "OutputErr"
                         ]
         writer = csv.DictWriter(csvfile, fieldnames=field_names)
-        writer.writeheader()
+        writer.writerow(dict(zip(writer.fieldnames, writer.fieldnames)))
         for entry in data:
             writer.writerow(entry)
 


### PR DESCRIPTION
writer.writeheader not available in python 2.6, which is shipped with SecureCRT by default. Edited lin 216 to use an compatible method of writing the header.